### PR TITLE
update README: specify the branch to `main` in the vim-plug config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ non-exhaustive list of the status of popular terminal emulators regarding OSC52
 ## Installation
 With [vim-plug](https://github.com/junegunn/vim-plug):
 ```vim
-Plug 'ojroques/vim-oscyank'
+Plug 'ojroques/vim-oscyank', {'branch': 'main'}
 ```
 
 ## Basic usage


### PR DESCRIPTION
Vim-plug use `master` as the default branch.If branch is not specified as `main`,it will cause an error: 
```
fatal: invalid reference: master
```